### PR TITLE
More efficent distance calculation

### DIFF
--- a/Assets/Scripts/GoDice/App/Modules/Dice/Shells/Shell.cs
+++ b/Assets/Scripts/GoDice/App/Modules/Dice/Shells/Shell.cs
@@ -20,8 +20,9 @@ namespace GoDice.App.Modules.Dice.Shells
             var value = 0;
             var distance = float.MaxValue;
             foreach (var pair in _values)
-            {
-                var lDist = Vector3.Distance(axis, pair.Value);
+            {   
+                Vector3 offset = axis - pair.Value;
+                var lDist = offset.sqrMagnitude;
                 if (lDist >= distance)
                     continue;
 


### PR DESCRIPTION
instead of using Vector3.distance using squaredMagnitued which removes the square root making the code more efficent, from unity docs: "If you only need to compare magnitudes of some vectors, you can compare squared magnitudes of them using sqrMagnitude (computing squared magnitudes is faster)."